### PR TITLE
Update open data portal url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ City of Chattanooga's Open Data Policy and Specification
 ========================================================
 
 ### **Timeline**
-The open data policy and specification language will be taken from Github on **April 7th 2014** to be crafted into the final legal langauge needed for the policy. Once the final language is complete and the policy is enacted, the policy and specification will be placed back on Github as well as on the City's website at www.chattanooga.gov and open data portal to be hosted at www.data.chattanooga.gov. 
+The open data policy and specification language will be taken from Github on **April 7th 2014** to be crafted into the final legal langauge needed for the policy. Once the final language is complete and the policy is enacted, the policy and specification will be placed back on Github as well as on the City's website at www.chattanooga.gov and open data portal to be hosted at [data.chattanooga.gov](data.chattanooga.gov). 
 
 ### **Expectations**
 This posting of the proposed open data policy and specification is an opportunity to garner greater input and feedback before the final version of the open data policy and specification is enacted. 


### PR DESCRIPTION
While we should probably ensure that it works with the `www`, the canonical form of the url should be `data.chattanooga.gov`
